### PR TITLE
#2 add chatgpt transcription and create speech commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ These are some of growing set of tools and experiments around ChatGPT.
 I started writing this for my own use in my sparetime and am extending it whenever I need something,
 but most of that is already pretty stable, so you are welcome to use them, too!
 I'll mark things that are new and thus unstable.
+As far as the tools are web-based, they are deployed at the
+[Github site](https://stoerr.github.io/chatGPTtools/) of this project.
+
+https://stoerr.github.io/chatGPTtools/chatgpttools/0README.html
 If you'd like to know what I'm professionally doing with ChatGPT,
 [this](https://github.com/ist-dresden/composum-chatgpt-integration) might be more interesting for you.
 

--- a/bin/chatgptlistmodels
+++ b/bin/chatgptlistmodels
@@ -8,6 +8,6 @@ fi
 # read OPENAI_API_KEY from file $HOME/.openaiapi
 OPENAI_API_KEY=$(cat $HOME/.openaiapi)
 
-curl -s https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY" | jq '.data[] | del(.permission)'
+curl -s https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY" | jq '.data[] | del(.permission)' | jq .id | sort | less
 
 # curl -s https://api.openai.com/v1/models/gpt-3.5-turbo -H "Authorization: Bearer $OPENAI_API_KEY"

--- a/bin/chatgptspeak
+++ b/bin/chatgptspeak
@@ -11,7 +11,7 @@ input_text=""
 
 # Function to display usage
 usage() {
-  echo "Usage: $0 [-m model] [-v voice] [-r format] [-s speed] [-o output_file] [-f text_file] [input_text]"
+  echo "Usage: $(basename $0) [-m model] [-v voice] [-r format] [-s speed] [-o output_file] [-f text_file] [input_text]"
   echo
   echo "Generates audio from input text using OpenAI's TTS models."
   echo

--- a/bin/chatgptspeak
+++ b/bin/chatgptspeak
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Default values
+model="tts-1"
+voice="shimmer"
+format="mp3"
+speed="1"
+output_file=""
+text_file=""
+input_text=""
+
+# Function to display usage
+usage() {
+  echo "Usage: $0 [-m model] [-v voice] [-r format] [-s speed] [-o output_file] [-f text_file] [input_text]"
+  echo
+  echo "Generates audio from input text using OpenAI's TTS models."
+  echo
+  echo "Arguments:"
+  echo "  input_text           The text input to generate audio for (if -f is not used). Read from stdin if not provided."
+  echo
+  echo "Options:"
+  echo "  -m model             Model ID to use for text-to-speech. Default is '$model'."
+  echo "  -v voice             Voice to use for the generated audio. Default is '$voice'. Supported voices are alloy, echo, fable, onyx, nova, and shimmer."
+  echo "  -r format            Audio format of the response. Default is '$format'."
+  echo "  -s speed             Speed of the generated audio, from 0.25 to 4.0. Default is 1."
+  echo "  -o output_file       Output file to write the audio to. If not provided, audio will be played using afplay."
+  echo "  -f text_file         Read input text from a file instead of stdin or command argument."
+  echo
+  echo "If no output file is specified with -o, the generated speech will be played immediately using the 'afplay' command."
+  echo "The script requires an OpenAI API key, which it will attempt to read from the OPENAI_API_KEY environment variable or the file \$HOME/.openaiapi."
+  exit 1
+}
+
+# Parse options
+while getopts "m:v:r:s:o:f:h?" opt; do
+  case "$opt" in
+    m) model="$OPTARG" ;;
+    v) voice="$OPTARG" ;;
+    r) format="$OPTARG" ;;
+    s) speed="$OPTARG" ;;
+    o) output_file="$OPTARG" ;;
+    f) text_file="$OPTARG" ;;
+    h|\?) usage ;;
+    *) usage ;;
+  esac
+done
+
+# Check for input text if no file is provided
+if [ -z "$text_file" ]; then
+  shift $((OPTIND -1))
+  input_text="$*"
+  if [ -z "$input_text" ]; then
+    if [ -t 0 ]; then  # Check if stdin is a terminal
+      usage
+    else
+      input_text=$(cat) # Read input from stdin
+    fi
+  fi
+else
+  if [ ! -f "$text_file" ]; then
+    echo "Error: Text file does not exist."
+    exit 2
+  fi
+  input_text=$(<"$text_file")
+fi
+
+# Prepare data payload
+json_payload=$(jq -n \
+                  --arg model "$model" \
+                  --arg input "$input_text" \
+                  --arg voice "$voice" \
+                  --argjson speed "$speed" \
+                  '{model: $model, input: $input, voice: $voice, speed: $speed}')
+
+# Check for API Key
+if [ -z "$OPENAI_API_KEY" ]; then
+  if [ -f "$HOME/.openaiapi" ]; then
+    OPENAI_API_KEY=$(cat "$HOME/.openaiapi")
+  fi
+fi
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "Error: OPENAI_API_KEY is not set."
+  exit 3
+fi
+
+# Curl command
+if [ -z "$output_file" ]; then
+  # create temporary file ending with .$format , delete it using trap on exit
+  output_file="$(mktemp -u).$format"
+  trap "rm -f $output_file" EXIT
+  curl "https://api.openai.com/v1/audio/speech" -s -S \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$json_payload" \
+    --output "$output_file"
+  afplay "$output_file"
+else
+  curl "https://api.openai.com/v1/audio/speech" -s -S \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$json_payload" \
+    --output "$output_file"
+fi
+
+exit 0

--- a/bin/chatgpttranscription
+++ b/bin/chatgpttranscription
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Function to show the usage of the script
+show_usage() {
+    echo "Usage: $0 -m model -l language -p prompt -r response_format -o output_file <audio_file>"
+    echo "  -m  Model ID to use for transcription. Default is 'whisper-1'."
+    echo "  -l  Language code of the input audio. Optional but improves accuracy."
+    echo "  -p  Text to guide the model's style. Optional."
+    echo "  -r  Response format of the transcript output. Options: json, text, srt, verbose_json, vtt. Default is 'text'."
+    echo "  -o  Output file to write the response to. If not provided, the response will be printed to stdout."
+    echo "  -h  Show this help message and exit."
+    echo "  <audio_file> The audio file to transcribe."
+    exit 1
+}
+
+# Initialize default values
+model="whisper-1"
+response_format="text"
+output_file=""
+
+# Parse options
+while getopts ":m:l:p:r:o:h" opt; do
+  case $opt in
+    m) model="$OPTARG"
+    ;;
+    l) language="$OPTARG"
+    ;;
+    p) prompt="$OPTARG"
+    ;;
+    r) response_format="$OPTARG"
+    ;;
+    o) output_file="$OPTARG"
+    ;;
+    h) show_usage
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+        show_usage
+    ;;
+    :) echo "Option -$OPTARG requires an argument." >&2
+       show_usage
+    ;;
+  esac
+done
+
+# Remove the options from the positional parameters
+shift $((OPTIND -1))
+
+# Check for the audio file argument
+if [ "$#" -ne 1 ]; then
+    echo "Error: You must provide an audio file to transcribe."
+    show_usage
+fi
+
+audio_file=$1
+
+# Verify that the audio file exists
+if [ ! -f "$audio_file" ]; then
+    echo "Error: The file $audio_file does not exist."
+    exit 1
+fi
+
+# Read the OpenAI API key
+if [ -z "$OPENAI_API_KEY" ]; then
+    if [ -f "$HOME/.openaiapi" ]; then
+        OPENAI_API_KEY=$(cat "$HOME/.openaiapi")
+    else
+        echo "Error: OPENAI_API_KEY is not set and no config file found at $HOME/.openaiapi."
+        exit 1
+    fi
+fi
+
+# Build the curl command
+curl_command="curl -X POST 'https://api.openai.com/v1/audio/transcriptions' -s -S"
+curl_command+=" -H 'Authorization: Bearer $OPENAI_API_KEY'"
+curl_command+=" -H 'Content-Type: multipart/form-data'"
+curl_command+=" -F 'file=@$audio_file'"
+curl_command+=" -F 'model=$model'"
+
+# Add optional parameters if provided
+[ -n "$language" ] && curl_command+=" -F 'language=$language'"
+[ -n "$prompt" ] && curl_command+=" -F 'prompt=$prompt'"
+curl_command+=" -F 'response_format=$response_format'"
+
+# Execute the curl command and handle the response
+if [ -n "$output_file" ]; then
+    eval "$curl_command" -o "$output_file"
+    echo "Response written to $output_file"
+else
+    eval "$curl_command"
+fi
+
+exit 0

--- a/bin/chatgpttranscription
+++ b/bin/chatgpttranscription
@@ -2,7 +2,7 @@
 
 # Function to show the usage of the script
 show_usage() {
-    echo "Usage: $0 -m model -l language -p prompt -r response_format -o output_file <audio_file>"
+    echo "Usage: $(basename $0) -m model -l language -p prompt -r response_format -o output_file <audio_file>"
     echo "  -m  Model ID to use for transcription. Default is 'whisper-1'."
     echo "  -l  Language code of the input audio. Optional but improves accuracy."
     echo "  -p  Text to guide the model's style. Optional."

--- a/docs/ChatGPTBookmarklet/ChatGPTBookmarklet-impl.js
+++ b/docs/ChatGPTBookmarklet/ChatGPTBookmarklet-impl.js
@@ -171,8 +171,8 @@
                 const isde = this.lang === 'de';
                 const loadinstruction = isde ? 'Rufe bitte den Text ab, für den der Prompt ausgeführt werden wird, und gib genau diesen Text ohne weitere Kommentare aus.'
                     : 'Please retrieve the text for which you are going to execute a prompt, and print exactly that text, without any additional comments.' ;
-                const promptinstruction = isde ? 'Die folgende Anweisung bezieht sich speziell auf den Text, der soeben abgerufen und angezeigt haben. Wenn ich von "dem Text" spreche, beziehe ich mich auf genau diesen Text. Bitte denke daran, wenn Du den folgenden Prompt ausführst:\n\nPROMPT:\n\n'
-                : 'The following instruction is specifically about the text you\'ve just retrieved and displayed. Whenever I refer to "the text", I\'m referencing this exact piece of content. Please keep this in mind while executing the following prompt:\n\nPROMPT:\n\n';
+                const promptinstruction = isde ? 'Die folgende Anweisung bezieht sich speziell auf den Text, der soeben abgerufen und angezeigt haben. Wenn ich von "dem Text" oder "der Seite" spreche, beziehe ich mich auf genau diesen Text. Bitte denke daran, wenn Du den folgenden Prompt ausführst:\n\nPROMPT:\n\n'
+                : 'The following instruction is specifically about the text you\'ve just retrieved and displayed. Whenever I refer to "the text" or "the page", I\'m referencing this exact piece of content. Please keep this in mind while executing the following prompt:\n\nPROMPT:\n\n';
                 messages = [
                     {role: 'user', content: loadinstruction},
                     {role: 'assistant', content: text},

--- a/docs/chatgpttools/0README.html
+++ b/docs/chatgpttools/0README.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>ChatGPT tools and experiments</title>
+    <title>ChatGPT web tools and experiments</title>
     <meta name="description"
           content="Ask a quick question and get a response from ChatGPT, without actually having a chat. This is often much quicker than the chat.">
     <link href="//cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="canonical" href="https://stoerr.github.io/chatGPTtools/chatgpttools/0README.html" />
+    <link rel="shortcut icon" type="image/x-icon" href="/chatGPTtools/favicon.ico">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-SL01MYCNDC"></script>
     <script>

--- a/docs/chatgpttools/gptchatswithitself-advanced.html
+++ b/docs/chatgpttools/gptchatswithitself-advanced.html
@@ -6,6 +6,7 @@
     <title data-detext="ChatGPT chattet mit sich selbst.">ChatGPT chats with itself.</title>
     <meta name="description"
           content="A fun little app that allows two instances of ChatGPT with different settings to chat with each other.">
+    <link rel="shortcut icon" type="image/x-icon" href="/chatGPTtools/favicon.ico">
     <link href="//cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/docs/chatgpttools/gptchatswithitself.html
+++ b/docs/chatgpttools/gptchatswithitself.html
@@ -6,6 +6,7 @@
     <title data-detext="ChatGPT chattet mit sich selbst.">ChatGPT chats with itself.</title>
     <meta name="description"
           content="A fun little app that allows two instances of ChatGPT with different settings to chat with each other.">
+    <link rel="shortcut icon" type="image/x-icon" href="/chatGPTtools/favicon.ico">
     <link href="//cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/docs/chatgpttools/multiplemessagechat.html
+++ b/docs/chatgpttools/multiplemessagechat.html
@@ -6,6 +6,7 @@
     <title>ChatGPT multiple message chat</title>
     <meta name="description"
           content="Testbed for executing chats with several messages">
+    <link rel="shortcut icon" type="image/x-icon" href="/chatGPTtools/favicon.ico">
     <link href="//cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/docs/chatgpttools/multiplemessagechat.html
+++ b/docs/chatgpttools/multiplemessagechat.html
@@ -292,6 +292,7 @@
                 messages.push({"role": type, "content": message});
             }
         });
+        removeEmptyMessages();
         adjustTextAreas();
         submitToGPT(messages, processResult, onError);
     }

--- a/docs/chatgpttools/quickchatgpt.html
+++ b/docs/chatgpttools/quickchatgpt.html
@@ -6,6 +6,8 @@
     <title>ChatGPT quick question</title>
     <meta name="description"
           content="Ask a quick question and get a response from ChatGPT, without actually having a chat. This is often much quicker than the chat.">
+    <link rel="shortcut icon" type="image/x-icon" href="/chatGPTtools/favicon.ico">
+    <link rel="canonical" href="https://stoerr.github.io/chatGPTtools/chatgpttools/0README.html" />
     <link href="//cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
     <link href="//cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="shortcut icon" type="image/x-icon" href="/chatGPTtools/favicon.ico">
+    <link rel="canonical" href="https://stoerr.github.io/chatGPTtools/index.html" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-SL01MYCNDC"></script>
     <script>
@@ -34,9 +35,9 @@
                         In addition to the command line tools in
                         <a href="https://github.com/stoerr/chatGPTtools">https://github.com/stoerr/chatGPTtools</a>,
                         there are some more or less interesting
-                        <a href=""chatgpttools/0README.html>experiments and ChatGPT related toy applications</a> here, and I have
-                        some ChatGPT related bookmarklets - see below. These are hosted for your convenience on
-                        <a href="https://stoerr.github.io/chatGPTtools/">https://stoerr.github.io/chatGPTtools/</a> .
+                        <a href="chatgpttools/0README.html">experiments and ChatGPT related toy web applications</a> here, and I have
+                        some ChatGPT related bookmarklets - see below. (All this is hosted for your convenience here on
+                        <a href="https://stoerr.github.io/chatGPTtools/">https://stoerr.github.io/chatGPTtools/</a>).
                     </p>
                     <p class="card-text">
                         To install the bookmarklets in your browser, you can drag the following links into your
@@ -54,27 +55,10 @@
 
                     <hr>
 
-                    <h4 class="card-subtitle mb-2">Grab Styles Bookmarklet</h4>
+                    <h4 class="card-subtitle mb-2">Experiments and ChatGPT related toy web applications</h4>
                     <p class="card-text">
-                        This lets you select an element in the page and then copies out just that element and its
-                        subelements, and all CSS
-                        rules that apply to any of those. That way you can copy out the HTML and CSS needed to have
-                        ChatGPT answer questions
-                        about the CSS. Press 'h' to see the help.
-                        See also my blog entry <a href="http://www.stoerr.net/blog/2023-05-10-cssWithChatGPT.html">Some
-                        experiences using ChatGPT to develop CSS</a> for what this is good for.
+                        See <a href="chatgpttools/0README.html">here</a> for a list.
                     </p>
-
-                    <p class="card-text">Bookmarklet to drag: <a id="grabstyles"></a></p>
-
-                    <script>
-                        var bookmarklet = "javascript:(function()%7Bjavascript%3A%2F*net.stoerr.chatGPT.grabStyles*%2F(function () %7B%0A    function load(basePath) %7B%0A        if (!window.netStoerrGrabStyles) %7B%0A            var script %3D document.createElement(%27script%27)%3B%0A            script.type %3D %27text%2Fjavascript%27%3B%0A            script.src %3D basePath %2B %27%2FgrabStyles.js%27%3B%0A            script.onload %3D function () %7B%0A                window.netStoerrGrabStyles.init(basePath)%3B%0A                window.netStoerrGrabStyles.start()%3B%0A            %7D%3B%0A            document.body.appendChild(script)%3B%0A        %7D else %7B%0A            window.netStoerrGrabStyles.start()%3B%0A        %7D%0A    %7D%0A%0A    load(%27THEURL%27)%3B%0A%7D)()%3B%7D)()";
-                        // https%3A%2F%2Fstoerr.github.io%2FchatGPTtools%2FgrabStyles
-                        var url = baseurl + "grabStyles";
-                        var element = document.getElementById("grabstyles");
-                        element.setAttribute("href", bookmarklet.replace("THEURL", encodeURIComponent(url)));
-                        element.innerText = "Grab Styles";
-                    </script>
 
                     <hr>
 
@@ -125,6 +109,30 @@
                                 element.innerText = "Enter a ChatGPT API Key first.";
                             }
                         }
+                    </script>
+
+                    <hr>
+
+                    <h4 class="card-subtitle mb-2">Grab Styles Bookmarklet</h4>
+                    <p class="card-text">
+                        This lets you select an element in the page and then copies out just that element and its
+                        subelements, and all CSS
+                        rules that apply to any of those. That way you can copy out the HTML and CSS needed to have
+                        ChatGPT answer questions
+                        about the CSS. Press 'h' to see the help.
+                        See also my blog entry <a href="http://www.stoerr.net/blog/2023-05-10-cssWithChatGPT.html">Some
+                        experiences using ChatGPT to develop CSS</a> for what this is good for.
+                    </p>
+
+                    <p class="card-text">Bookmarklet to drag: <a id="grabstyles"></a></p>
+
+                    <script>
+                        var bookmarklet = "javascript:(function()%7Bjavascript%3A%2F*net.stoerr.chatGPT.grabStyles*%2F(function () %7B%0A    function load(basePath) %7B%0A        if (!window.netStoerrGrabStyles) %7B%0A            var script %3D document.createElement(%27script%27)%3B%0A            script.type %3D %27text%2Fjavascript%27%3B%0A            script.src %3D basePath %2B %27%2FgrabStyles.js%27%3B%0A            script.onload %3D function () %7B%0A                window.netStoerrGrabStyles.init(basePath)%3B%0A                window.netStoerrGrabStyles.start()%3B%0A            %7D%3B%0A            document.body.appendChild(script)%3B%0A        %7D else %7B%0A            window.netStoerrGrabStyles.start()%3B%0A        %7D%0A    %7D%0A%0A    load(%27THEURL%27)%3B%0A%7D)()%3B%7D)()";
+                        // https%3A%2F%2Fstoerr.github.io%2FchatGPTtools%2FgrabStyles
+                        var url = baseurl + "grabStyles";
+                        var element = document.getElementById("grabstyles");
+                        element.setAttribute("href", bookmarklet.replace("THEURL", encodeURIComponent(url)));
+                        element.innerText = "Grab Styles";
                     </script>
 
                 </div>


### PR DESCRIPTION
Usage: chatgpttranscription -m model -l language -p prompt -r response_format -o output_file <audio_file>
  -m  Model ID to use for transcription. Default is 'whisper-1'.
  -l  Language code of the input audio. Optional but improves accuracy.
  -p  Text to guide the model's style. Optional.
  -r  Response format of the transcript output. Options: json, text, srt, verbose_json, vtt. Default is 'text'.
  -o  Output file to write the response to. If not provided, the response will be printed to stdout.
  -h  Show this help message and exit.
  <audio_file> The audio file to transcribe.

---

Usage: chatgptspeak [-m model] [-v voice] [-r format] [-s speed] [-o output_file] [-f text_file] [input_text]

Generates audio from input text using OpenAI's TTS models.

Arguments:
  input_text           The text input to generate audio for (if -f is not used). Read from stdin if not provided.

Options:
  -m model             Model ID to use for text-to-speech. Default is 'tts-1'.
  -v voice             Voice to use for the generated audio. Default is 'shimmer'. Supported voices are alloy, echo, fable, onyx, nova, and shimmer.
  -r format            Audio format of the response. Default is 'mp3'.
  -s speed             Speed of the generated audio, from 0.25 to 4.0. Default is 1.
  -o output_file       Output file to write the audio to. If not provided, audio will be played using afplay.
  -f text_file         Read input text from a file instead of stdin or command argument.

If no output file is specified with -o, the generated speech will be played immediately using the 'afplay' command.
The script requires an OpenAI API key, which it will attempt to read from the OPENAI_API_KEY environment variable or the file $HOME/.openaiapi.